### PR TITLE
[feat] 회원가입 api 연결 및 auth 도메인 고도화 #49

### DIFF
--- a/app/src/main/java/com/iccas/zen/data/dto/auth/request/SignUpRequest.kt
+++ b/app/src/main/java/com/iccas/zen/data/dto/auth/request/SignUpRequest.kt
@@ -1,0 +1,7 @@
+package com.iccas.zen.data.dto.auth.request
+
+data class SignUpRequest(
+    val nickname: String,
+    val email: String,
+    val password: String
+)

--- a/app/src/main/java/com/iccas/zen/data/remote/AuthApi.kt
+++ b/app/src/main/java/com/iccas/zen/data/remote/AuthApi.kt
@@ -1,5 +1,6 @@
 package com.iccas.zen.data.remote
 import com.iccas.zen.data.dto.auth.request.LoginRequest
+import com.iccas.zen.data.dto.auth.request.SignUpRequest
 import com.iccas.zen.data.dto.auth.response.LoginResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -8,4 +9,6 @@ import retrofit2.http.POST
 interface AuthApi {
     @POST("/api/v1/auth/authenticate")
     suspend fun authenticate(@Body loginRequest: LoginRequest): Response<LoginResponse>
+    @POST("/api/v1/auth/register")
+    suspend fun register(@Body signUpRequest: SignUpRequest): Response<LoginResponse>
 }

--- a/app/src/main/java/com/iccas/zen/data/remote/RetrofitModule.kt
+++ b/app/src/main/java/com/iccas/zen/data/remote/RetrofitModule.kt
@@ -16,7 +16,7 @@ object RetrofitModule {
         .addInterceptor(loggingInterceptor)
         .build()
 
-    val retrofit: Retrofit by lazy {
+    private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
             .client(client)

--- a/app/src/main/java/com/iccas/zen/navigation/NavGraph.kt
+++ b/app/src/main/java/com/iccas/zen/navigation/NavGraph.kt
@@ -34,7 +34,7 @@ fun NavGraph(
     val navController = rememberNavController()
 
 
-    NavHost(navController, startDestination = "diagnosis") {
+    NavHost(navController, startDestination = "onboarding1") {
         composable("onboarding1") { OnboardingPage1(navController) }
         composable("onboarding2") { OnboardingPage2(navController) }
         composable("onboarding3") { OnboardingPage3(navController) }

--- a/app/src/main/java/com/iccas/zen/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/AuthViewModel.kt
@@ -25,9 +25,9 @@ class AuthViewModel : ViewModel() {
             try {
                 val response = authApi.authenticate(LoginRequest(email, password));
                 _authentication.value = response.body()
-                Log.d("UserViewModel", "Fetched user: $response")
+                Log.d("AuthViewModel", "login: $response")
             } catch (e: Exception) {
-                Log.e("UserViewModel", "Error fetching user", e)
+                Log.e("AuthViewModel", "Error login", e)
             }
         }
     }
@@ -37,9 +37,9 @@ class AuthViewModel : ViewModel() {
             try {
                 val response = authApi.register(SignUpRequest(nickname, email, password));
                 _authentication.value = response.body()
-                Log.d("UserViewModel", "Fetched user: $response")
+                Log.d("AuthViewModel", "sign up: $response")
             } catch (e: Exception) {
-                Log.e("UserViewModel", "Error fetching user", e)
+                Log.e("AuthViewModel", "Error sign up", e)
             }
         }
     }

--- a/app/src/main/java/com/iccas/zen/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/AuthViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import android.util.Log
 import com.iccas.zen.data.dto.auth.request.LoginRequest
+import com.iccas.zen.data.dto.auth.request.SignUpRequest
 import com.iccas.zen.data.dto.auth.response.LoginResponse
 import com.iccas.zen.data.remote.AuthApi
 import com.iccas.zen.data.remote.RetrofitModule
@@ -23,6 +24,18 @@ class AuthViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val response = authApi.authenticate(LoginRequest(email, password));
+                _authentication.value = response.body()
+                Log.d("UserViewModel", "Fetched user: $response")
+            } catch (e: Exception) {
+                Log.e("UserViewModel", "Error fetching user", e)
+            }
+        }
+    }
+
+    fun signUp(nickname: String, email: String, password: String) {
+        viewModelScope.launch {
+            try {
+                val response = authApi.register(SignUpRequest(nickname, email, password));
                 _authentication.value = response.body()
                 Log.d("UserViewModel", "Fetched user: $response")
             } catch (e: Exception) {

--- a/app/src/main/java/com/iccas/zen/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/LoginScreen.kt
@@ -99,7 +99,7 @@ fun LoginScreen(navController: NavController) {
                 Spacer(modifier = Modifier.height(100.dp))
 
                 Button(
-                    onClick = { authViewModel.login(emailState.value.toString(), passwordState.value.toString() ) },
+                    onClick = { authViewModel.login(emailState.value, passwordState.value ) },
                     colors = ButtonDefaults.buttonColors(containerColor = Brown40),
                     shape = RoundedCornerShape(50.dp),
                     modifier = Modifier
@@ -116,9 +116,9 @@ fun LoginScreen(navController: NavController) {
             }
             authentication?.let { response ->
                 LaunchedEffect(response) {
-                    Log.d("SignupViewModel", "Status: ${response.status}")
-                    Log.d("SignupViewModel", "Message: ${response.message}")
-                    Log.d("SignupViewModel", "Data: ${response.data}")
+                    Log.d("login", "Status: ${response.status}")
+                    Log.d("login", "Message: ${response.message}")
+                    Log.d("login", "Data: ${response.data}")
 
                     if (response.status == 200) {
                         navController.navigate("char_main")

--- a/app/src/main/java/com/iccas/zen/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/LoginScreen.kt
@@ -1,23 +1,15 @@
 package com.iccas.zen.presentation.auth
 
 import android.util.Log
-import androidx.compose.foundation.border
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -26,19 +18,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.iccas.zen.presentation.auth.authComponents.AuthButton
+import com.iccas.zen.presentation.auth.authComponents.UserInfoInputBox
 import com.iccas.zen.presentation.components.BasicBackground
 import com.iccas.zen.ui.theme.Brown40
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginScreen(navController: NavController) {
     BasicBackground {
@@ -47,6 +38,7 @@ fun LoginScreen(navController: NavController) {
 
         val authViewModel: AuthViewModel = viewModel()
         val authentication by authViewModel.authentication.collectAsState()
+        val context = LocalContext.current
 
         Box(
             modifier = Modifier
@@ -54,65 +46,45 @@ fun LoginScreen(navController: NavController) {
                 .padding(16.dp)
         ) {
             Column(
+                modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier.fillMaxSize()
+                verticalArrangement = Arrangement.Center
             ) {
-                TextField(
-                    shape = RoundedCornerShape(50.dp),
+                UserInfoInputBox(
                     value = emailState.value,
                     onValueChange = { emailState.value = it },
-                    label = { Text("email") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label ="email",
+                    keyboardType = KeyboardType.Email
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextField(
-                    shape = RoundedCornerShape(50.dp),
+                Spacer(modifier = Modifier.height(10.dp))
+
+                UserInfoInputBox(
                     value = passwordState.value,
                     onValueChange = { passwordState.value = it },
-                    label = { Text("password") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label = "password",
+                    keyboardType = KeyboardType.Password,
+                    visualTransformation = PasswordVisualTransformation()
                 )
                 Spacer(modifier = Modifier.height(100.dp))
 
-                Button(
-                    onClick = { authViewModel.login(emailState.value, passwordState.value ) },
-                    colors = ButtonDefaults.buttonColors(containerColor = Brown40),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp)
-                ) {
-                    Text(
-                        "Login with email",
-                        color = Color.White,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
+                AuthButton(
+                    onClick = {
+                        if (emailState.value == "") {
+                            Toast.makeText(context, "Please enter your email!", Toast.LENGTH_SHORT)
+                                .show()
+                        } else if (passwordState.value == "") {
+                            Toast.makeText(
+                                context,
+                                "Please enter your password!",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            authViewModel.login(emailState.value, passwordState.value)
+                        }
+                    },
+                    buttonColor = Brown40,
+                    text = "Login with email"
+                )
             }
             authentication?.let { response ->
                 LaunchedEffect(response) {
@@ -122,18 +94,19 @@ fun LoginScreen(navController: NavController) {
 
                     if (response.status == 200) {
                         navController.navigate("char_main")
+                    } else {
+                        Toast.makeText(context, "Login failed", Toast.LENGTH_SHORT).show()
                     }
                 }
-
-                Text(
-                    text = "copyright © S2",
-                    color = Color.Black,
-                    fontSize = 12.sp,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp)
-                )
             }
+            Text(
+                text = "copyright © S2",
+                color = Color.Black,
+                fontSize = 12.sp,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/iccas/zen/presentation/auth/SignupScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/SignupScreen.kt
@@ -1,10 +1,8 @@
 package com.iccas.zen.presentation.auth
 
 import android.util.Log
-import androidx.compose.foundation.border
+import android.widget.Toast
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,20 +12,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.iccas.zen.presentation.auth.authComponents.AuthButton
+import com.iccas.zen.presentation.auth.authComponents.UserInfoInputBox
 
 import com.iccas.zen.presentation.components.BasicBackground
 import com.iccas.zen.ui.theme.Brown40
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupScreen(navController: NavController) {
     val nicknameState = remember { mutableStateOf("") }
@@ -37,7 +34,7 @@ fun SignupScreen(navController: NavController) {
 
     val authViewModel: AuthViewModel = viewModel()
     val authentication by authViewModel.authentication.collectAsState()
-
+    val context = LocalContext.current
 
     BasicBackground {
         Box(
@@ -50,105 +47,55 @@ fun SignupScreen(navController: NavController) {
                 verticalArrangement = Arrangement.Center,
                 modifier = Modifier.fillMaxSize()
             ) {
-                TextField(
+                UserInfoInputBox(
                     value = nicknameState.value,
                     onValueChange = { nicknameState.value = it },
-                    label = { Text("nickname") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label = "nickname",
+                    keyboardType = KeyboardType.Text
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextField(
+                Spacer(modifier = Modifier.height(10.dp))
+
+                UserInfoInputBox(
                     value = emaiState.value,
                     onValueChange = { emaiState.value = it },
-                    label = { Text("email") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label = "email",
+                    keyboardType = KeyboardType.Text
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextField(
+                Spacer(modifier = Modifier.height(10.dp))
+
+                UserInfoInputBox(
                     value = passwordState.value,
                     onValueChange = { passwordState.value = it },
-                    label = { Text("password") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label = "password",
+                    keyboardType = KeyboardType.Password
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                TextField(
+                Spacer(modifier = Modifier.height(10.dp))
+
+                UserInfoInputBox(
                     value = confirmPasswordState.value,
                     onValueChange = { confirmPasswordState.value = it },
-                    label = { Text("Confirm Password") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    colors = TextFieldDefaults.textFieldColors(
-                        containerColor = Color.White // 내부 배경색 변경
-                    ),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 2.dp,
-                            color = Color.Black,
-                            shape = RoundedCornerShape(50.dp)
-                        )
-                        .clip(RoundedCornerShape(50.dp))
+                    label = "confirm password",
+                    keyboardType = KeyboardType.Password
                 )
-                Spacer(modifier = Modifier.height(16.dp))
-                Button(
+                Spacer(modifier = Modifier.height(50.dp))
+
+                AuthButton(
                     onClick = {
-                        authViewModel.signUp(
-                            nicknameState.value,
-                            emaiState.value,
-                            passwordState.value
-                        )
+                        if (nicknameState.value == "") {
+                            Toast.makeText(context, "Please enter your nickname!", Toast.LENGTH_SHORT).show()
+                        } else if (emaiState.value =="") {
+                            Toast.makeText(context, "Please enter your email!", Toast.LENGTH_SHORT).show()
+                        } else if (passwordState.value =="") {
+                            Toast.makeText(context, "Please enter your password!", Toast.LENGTH_SHORT).show()
+                        } else if (passwordState.value != confirmPasswordState.value){
+                            Toast.makeText(context, "Passwords do not match", Toast.LENGTH_SHORT).show()
+                        } else {
+                            authViewModel.signUp(nicknameState.value, emaiState.value, passwordState.value)
+                        }
                     },
-                    colors = ButtonDefaults.buttonColors(containerColor = Brown40),
-                    shape = RoundedCornerShape(50.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp) // 버튼 높이 설정
-                ) {
-                    Text(
-                        "Sign up",
-                        color = Color.White,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
+                    buttonColor = Brown40,
+                    text = "Sign up"
+                )
             }
             authentication?.let { response ->
                 LaunchedEffect(response) {
@@ -158,18 +105,20 @@ fun SignupScreen(navController: NavController) {
 
                     if (response.status == 200) {
                         navController.navigate("char_main")
+                    } else {
+                        Toast.makeText(context, "Sign up failed", Toast.LENGTH_SHORT).show()
                     }
                 }
-
-                Text(
-                    text = "copyright © S2",
-                    color = Color.Black,
-                    fontSize = 12.sp,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp)
-                )
             }
+
+            Text(
+                text = "copyright © S2",
+                color = Color.Black,
+                fontSize = 12.sp,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/iccas/zen/presentation/auth/SignupScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/SignupScreen.kt
@@ -1,11 +1,13 @@
 package com.iccas.zen.presentation.auth
 
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,6 +30,7 @@ import com.iccas.zen.ui.theme.Brown40
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupScreen(navController: NavController) {
+    val nicknameState = remember { mutableStateOf("") }
     val emaiState = remember { mutableStateOf("") }
     val passwordState = remember { mutableStateOf("") }
     val confirmPasswordState = remember { mutableStateOf("") }
@@ -48,9 +51,28 @@ fun SignupScreen(navController: NavController) {
                 modifier = Modifier.fillMaxSize()
             ) {
                 TextField(
+                    value = nicknameState.value,
+                    onValueChange = { nicknameState.value = it },
+                    label = { Text("nickname") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                    colors = TextFieldDefaults.textFieldColors(
+                        containerColor = Color.White // 내부 배경색 변경
+                    ),
+                    shape = RoundedCornerShape(50.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 2.dp,
+                            color = Color.Black,
+                            shape = RoundedCornerShape(50.dp)
+                        )
+                        .clip(RoundedCornerShape(50.dp))
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                TextField(
                     value = emaiState.value,
                     onValueChange = { emaiState.value = it },
-                    label = { Text("Email") },
+                    label = { Text("email") },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                     colors = TextFieldDefaults.textFieldColors(
                         containerColor = Color.White // 내부 배경색 변경
@@ -69,7 +91,7 @@ fun SignupScreen(navController: NavController) {
                 TextField(
                     value = passwordState.value,
                     onValueChange = { passwordState.value = it },
-                    label = { Text("Password") },
+                    label = { Text("password") },
                     visualTransformation = PasswordVisualTransformation(),
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                     colors = TextFieldDefaults.textFieldColors(
@@ -108,27 +130,46 @@ fun SignupScreen(navController: NavController) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Button(
                     onClick = {
-                        navController.navigate("welcome")
-                         },
+                        authViewModel.signUp(
+                            nicknameState.value,
+                            emaiState.value,
+                            passwordState.value
+                        )
+                    },
                     colors = ButtonDefaults.buttonColors(containerColor = Brown40),
                     shape = RoundedCornerShape(50.dp),
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(50.dp) // 버튼 높이 설정
                 ) {
-                    Text("Sign up", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+                    Text(
+                        "Sign up",
+                        color = Color.White,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+            authentication?.let { response ->
+                LaunchedEffect(response) {
+                    Log.d("sign up", "Status: ${response.status}")
+                    Log.d("sign up", "Message: ${response.message}")
+                    Log.d("sign up", "Data: ${response.data}")
+
+                    if (response.status == 200) {
+                        navController.navigate("char_main")
+                    }
                 }
 
+                Text(
+                    text = "copyright © S2",
+                    color = Color.Black,
+                    fontSize = 12.sp,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp)
+                )
             }
-
-            Text(
-                text = "copyright © S2",
-                color = Color.Black,
-                fontSize = 12.sp,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 16.dp)
-            )
         }
     }
 }

--- a/app/src/main/java/com/iccas/zen/presentation/auth/WelcomeScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/WelcomeScreen.kt
@@ -1,20 +1,15 @@
 package com.iccas.zen.presentation.auth
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.iccas.zen.R
+import com.iccas.zen.presentation.auth.authComponents.AuthButton
 import com.iccas.zen.presentation.components.BasicBackground
 import com.iccas.zen.ui.theme.Brown40
 
@@ -42,49 +38,37 @@ fun WelcomeScreen(navController: NavController) {
                 modifier = Modifier.fillMaxSize()
             ) {
                 Image(
-                    painter = painterResource(id = R.drawable.zen_brown_logo), // 테이프가 붙은 종이 이미지
+                    painter = painterResource(id = R.drawable.zen_brown_logo),
                     contentDescription = null,
                     modifier = Modifier
                         .width(100.dp)
-                        .height(100.dp) // 높이를 더 키움
+                        .height(100.dp)
                         .align(Alignment.CenterHorizontally)
                 )
                 Spacer(modifier = Modifier.height(200.dp))
 
-                Button(
+                AuthButton(
                     onClick = { navController.navigate("login") },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(2.dp, color = Brown40),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp) // 버튼 높이 설정
-                ) {
-                    Text("Login with email", color = Brown40, fontSize = 20.sp)
-                }
+                    buttonColor = Color.White,
+                    text = "Login with email",
+                    textColor = Brown40
+                )
                 Spacer(modifier = Modifier.height(16.dp))
 
-                Button(
+                AuthButton(
                     onClick = { /* Google 로그인 로직 추가 */ },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(2.dp, color = Brown40),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp) // 버튼 높이 설정
-                ) {
-                    Text("Continue with Google", color = Brown40, fontSize = 20.sp)
-                }
+                    buttonColor = Brown40,
+                    text = "Continue with Google"
+                )
                 Spacer(modifier = Modifier.height(16.dp))
+
                 Text("Don't you have an account yet?", color = Brown40, fontSize = 12.sp, fontWeight = FontWeight.Bold)
-                TextButton(
+
+                AuthButton(
                     onClick = { navController.navigate("signup") },
-                    colors = ButtonDefaults.buttonColors(containerColor = Brown40),
-                    border = BorderStroke(2.dp, color = Brown40),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp) // 버튼 높이 설정
-                ) {
-                    Text("Sign up with email", color = Color.White, fontSize = 20.sp)
-                }
+                    buttonColor = Brown40,
+                    text = "Sign up with email"
+                )
             }
 
             Text(

--- a/app/src/main/java/com/iccas/zen/presentation/auth/authComponents/AuthButton.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/authComponents/AuthButton.kt
@@ -1,0 +1,41 @@
+package com.iccas.zen.presentation.auth.authComponents
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.iccas.zen.ui.theme.Brown40
+
+@Composable
+fun AuthButton(
+    onClick: () -> Unit,
+    buttonColor: Color,
+    text: String,
+    textColor: Color = Color.White
+) {
+    Button(
+        onClick = { onClick() },
+        colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
+        shape = RoundedCornerShape(50.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .border(width = 2.dp, color = Brown40, shape = RoundedCornerShape(50.dp))
+    ) {
+        Text(
+            text,
+            color = textColor,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/app/src/main/java/com/iccas/zen/presentation/auth/authComponents/UserInfoInputBox.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/auth/authComponents/UserInfoInputBox.kt
@@ -1,0 +1,44 @@
+package com.iccas.zen.presentation.auth.authComponents
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.iccas.zen.ui.theme.Brown40
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserInfoInputBox(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    keyboardType: KeyboardType,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    TextField(
+        shape = RoundedCornerShape(50.dp),
+        value = value,
+        onValueChange = { onValueChange(it) },
+        label = { Text(label) },
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        visualTransformation = visualTransformation,
+        colors = TextFieldDefaults.textFieldColors(
+            containerColor = Color.White
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(width = 2.dp, color = Brown40, shape = RoundedCornerShape(50.dp))
+            .clip(RoundedCornerShape(50.dp))
+    )
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #49

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 api를 연결하였습니다.
- auth 도메인을 컴포넌트화하고, 회원가입/로그인 로직에서 유효성 처리 및 예외를 다루었습니다.

## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->
- 입력란을 다 채우지 않으면 회원가입/로그인이 불가능하고, toast message가 화면에 나타납니다.
<img width="824" alt="스크린샷 2024-07-19 오전 2 50 06" src="https://github.com/user-attachments/assets/609026a1-0a93-4fef-8f1b-e76622153003">
