### PR TITLE
[feat] user 답변 저장 api 연동 및 화면 연동 #40

### DIFF
--- a/app/src/main/java/com/iccas/zen/data/dto/auth/request/EmotionDiaryPostRequest.kt
+++ b/app/src/main/java/com/iccas/zen/data/dto/auth/request/EmotionDiaryPostRequest.kt
@@ -1,0 +1,7 @@
+package com.iccas.zen.data.dto.auth.request
+
+data class EmotionDiaryPostRequest(
+    val userInput : String,
+    val character : String,
+    val emotionState : String
+)

--- a/app/src/main/java/com/iccas/zen/data/dto/auth/response/ApiResponse.kt
+++ b/app/src/main/java/com/iccas/zen/data/dto/auth/response/ApiResponse.kt
@@ -1,0 +1,6 @@
+package com.iccas.zen.data.dto.auth.response
+
+data class ApiResponse(
+    val status: Int,
+    val message: String
+)

--- a/app/src/main/java/com/iccas/zen/data/remote/DiaryApi.kt
+++ b/app/src/main/java/com/iccas/zen/data/remote/DiaryApi.kt
@@ -2,7 +2,6 @@ package com.iccas.zen.data.remote
 
 import com.iccas.zen.data.dto.auth.request.EmotionDiaryPostRequest
 import com.iccas.zen.data.dto.auth.response.ApiResponse
-import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/app/src/main/java/com/iccas/zen/data/remote/DiaryApi.kt
+++ b/app/src/main/java/com/iccas/zen/data/remote/DiaryApi.kt
@@ -1,0 +1,12 @@
+package com.iccas.zen.data.remote
+
+import com.iccas.zen.data.dto.auth.request.EmotionDiaryPostRequest
+import com.iccas.zen.data.dto.auth.response.ApiResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface DiaryApi {
+    @POST("/api/v1/emotion-diary")
+    suspend fun postEmotionDiary(@Body emotionDiaryPostRequest: EmotionDiaryPostRequest): ApiResponse
+}

--- a/app/src/main/java/com/iccas/zen/navigation/NavGraph.kt
+++ b/app/src/main/java/com/iccas/zen/navigation/NavGraph.kt
@@ -1,12 +1,12 @@
 package com.iccas.zen.navigation
 
-
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.iccas.zen.R
 import com.iccas.zen.SelectEmotionScreen
 import com.iccas.zen.presentation.character.CharScreen
 import com.iccas.zen.presentation.character.CollectionScreen
@@ -34,8 +34,7 @@ fun NavGraph(
 ) {
     val navController = rememberNavController()
 
-
-    NavHost(navController, startDestination = "recommend_measure_base") {
+    NavHost(navController, startDestination = "emotion_diary") {
         composable("onboarding1") { OnboardingPage1(navController) }
         composable("onboarding2") { OnboardingPage2(navController) }
         composable("onboarding3") { OnboardingPage3(navController) }
@@ -71,9 +70,6 @@ fun NavGraph(
             val route = backStackEntry.arguments?.getString("route") ?: "tetris_game"
             CountDownScreen(navController = navController, route = route)
         }
-        /* composable("game_select") {
-             GameSelectScreen(navController = navController)
-         }*/
         composable("tetris_game") {
             TetrisGameScreen(
                 measureHeartViewModel = measureHeartViewModel,
@@ -94,21 +90,24 @@ fun NavGraph(
             val score = backStackEntry.arguments?.getInt("score") ?: 0
             ResultScreen(score = score, navController = navController)
         }
-composable("heartreport")
-{
-    HeartReportScreen(navController)
-}
-        composable("heartreport2")
-        {
-           HeartReport2Screen(navController)
+        composable("heartreport") {
+            HeartReportScreen(navController)
+        }
+        composable("heartreport2") {
+            HeartReport2Screen(navController)
         }
         composable("high_heart_rate") {
             HighHeartRateScreen()
         }
-
-
-        composable("select_emotion") {
-            SelectEmotionScreen(navController = navController)
+        composable("select_emotion/{characterImageRes}/{characterDescription}",
+            arguments = listOf(
+                navArgument("characterImageRes") { type = NavType.IntType },
+                navArgument("characterDescription") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val characterImageRes = backStackEntry.arguments?.getInt("characterImageRes") ?: R.drawable.char_mozzi1
+            val characterDescription = backStackEntry.arguments?.getString("characterDescription") ?: "Mozzi"
+            SelectEmotionScreen(navController = navController, characterImageRes = characterImageRes, characterDescription = characterDescription)
         }
         composable(
             route = "tetris_game_over/level={level}/score={score}/lives={lives}/dateTime={dateTime}",
@@ -130,15 +129,17 @@ composable("heartreport")
             )
         }
         composable(
-            "chat_screen/{emojiResId}?prompt={prompt}",
+            "chat_screen/{emojiResId}?prompt={prompt}&characterDescription={characterDescription}",
             arguments = listOf(
                 navArgument("emojiResId") { type = NavType.IntType },
-                navArgument("prompt") { type = NavType.StringType; defaultValue = "" }
+                navArgument("prompt") { type = NavType.StringType; defaultValue = "" },
+                navArgument("characterDescription") { type = NavType.StringType; defaultValue = "Mozzi" }
             )
         ) { backStackEntry ->
             val emojiResId = backStackEntry.arguments?.getInt("emojiResId") ?: 0
             val prompt = backStackEntry.arguments?.getString("prompt") ?: ""
-            ChatScreen(navController, emojiResId, prompt)
+            val characterDescription = backStackEntry.arguments?.getString("characterDescription") ?: "Mozzi"
+            ChatScreen(navController, emojiResId, prompt, characterDescription)
         }
         composable("start_yoga") {
             StartYogaGameScreen(navController = navController)
@@ -164,7 +165,6 @@ composable("heartreport")
         composable("report/anger_game") {
             AngerGameSelect(navController = navController)
         }
-
         composable("report/self_diagnosis/{test_id}",
             arguments = listOf(navArgument("test_id") { type = NavType.IntType })
         ) {
@@ -197,6 +197,5 @@ composable("heartreport")
         composable("emotion_diary") {
             DiaryCharSelectScreen(navController = navController)
         }
-
     }
 }

--- a/app/src/main/java/com/iccas/zen/presentation/chatBot/ChatScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/chatBot/ChatScreen.kt
@@ -30,10 +30,15 @@ import com.iccas.zen.presentation.chatBot.components.TopBar
 import com.iccas.zen.ui.theme.Blue90
 
 @Composable
-fun ChatScreen(navController: NavHostController, emojiResId: Int, basicPrompt: String, viewModel: ChatViewModel = viewModel()) {
+fun ChatScreen(
+    navController: NavHostController,
+    emojiResId: Int,
+    basicPrompt: String,
+    characterDescription: String,
+    viewModel: ChatViewModel = viewModel()
+) {
     var userInput by remember { mutableStateOf("") }
     val messages by viewModel.messages.collectAsState()
-
 
     BasicBackgroundWithLogo {
         val coroutineScope = rememberCoroutineScope()
@@ -76,7 +81,7 @@ fun ChatScreen(navController: NavHostController, emojiResId: Int, basicPrompt: S
                     verticalArrangement = Arrangement.Top
                 ) {
                     items(messages.asReversed()) { message ->
-                        MessageItem(message, emojiResId)
+                        MessageItem(message, emojiResId, characterDescription)
                     }
                 }
             }
@@ -121,7 +126,9 @@ fun ChatScreen(navController: NavHostController, emojiResId: Int, basicPrompt: S
 }
 
 @Composable
-fun MessageItem(message: Message, emojiResId: Int) {
+fun MessageItem(message: Message, emojiResId: Int, characterDescription: String) {
+    val characterImageRes = getCharacterImageRes(characterDescription)
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -131,8 +138,8 @@ fun MessageItem(message: Message, emojiResId: Int) {
     ) {
         if (!message.isUser) {
             Image(
-                painter = painterResource(id = R.drawable.chat_bao),
-                contentDescription = "BAO",
+                painter = painterResource(id = characterImageRes),
+                contentDescription = characterDescription,
                 modifier = Modifier
                     .size(50.dp)
                     .padding(end = 8.dp)
@@ -142,12 +149,12 @@ fun MessageItem(message: Message, emojiResId: Int) {
             modifier = Modifier
                 .background(
                     color = if (message.isUser) Blue90 else Color.White,
-                    shape = RoundedCornerShape(12.dp) // 둥근 모서리를 위해 RoundedCornerShape 사용
+                    shape = RoundedCornerShape(12.dp)
                 )
                 .padding(16.dp)
         ) {
             Text(
-                text = message.text, // 사용자에게는 입력한 내용만 표시
+                text = message.text,
                 color = if (message.isUser) Color.Black else Color.Black,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Bold
@@ -162,5 +169,14 @@ fun MessageItem(message: Message, emojiResId: Int) {
                     .padding(start = 8.dp)
             )
         }
+    }
+}
+
+fun getCharacterImageRes(characterDescription: String): Int {
+    return when (characterDescription) {
+        "Mozzi" -> R.drawable.char_mozzi1
+        "BAO" -> R.drawable.char_bao1
+        "SKY" -> R.drawable.char_sky1
+        else -> R.drawable.char_mozzi1
     }
 }

--- a/app/src/main/java/com/iccas/zen/presentation/chatBot/ChatViewModel.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/chatBot/ChatViewModel.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.iccas.zen.BuildConfig
+import com.iccas.zen.data.dto.auth.request.EmotionDiaryPostRequest
+import com.iccas.zen.data.remote.DiaryApi
+import com.iccas.zen.data.remote.RetrofitModule
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.headers
@@ -24,6 +27,24 @@ class ChatViewModel : ViewModel() {
     val messages: StateFlow<List<Message>> get() = _messages
 
     private val client = HttpClient()
+
+    private val diaryApi = RetrofitModule.createService(DiaryApi::class.java)
+
+    fun postEmotionDiary(userInput: String, character: String, emotionState: String) {
+        viewModelScope.launch {
+            try {
+                val response = diaryApi.postEmotionDiary(
+                    EmotionDiaryPostRequest(
+                        userInput = userInput,
+                        character = character,
+                        emotionState = emotionState
+                    )
+                )
+            } catch (e: Exception) {
+                Log.e("ChatViewModel", "Error posting diary", e)
+            }
+        }
+    }
 
     fun sendMessage(userInput: String, prompt: String? = null) {
         val finalText = prompt?.let { "$it $userInput" } ?: userInput

--- a/app/src/main/java/com/iccas/zen/presentation/chatBot/DiaryCharSelectScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/chatBot/DiaryCharSelectScreen.kt
@@ -91,7 +91,7 @@ fun CharacterRow(character: String, characterImageRes: Int, navController: NavCo
             color = Color.Black
         )
         Button(
-            onClick = { navController.navigate("select_emotion") },
+            onClick = { navController.navigate("select_emotion/$characterImageRes/$characterDescription") },
             colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray)
         ) {
             Text(text = "chat", color = Color.Black, fontSize = 20.sp)

--- a/app/src/main/java/com/iccas/zen/presentation/chatBot/SelectEmotionScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/chatBot/SelectEmotionScreen.kt
@@ -12,14 +12,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import com.iccas.zen.R
 import com.iccas.zen.presentation.chatBot.ChatViewModel
 import com.iccas.zen.presentation.components.BasicBackgroundWithLogo
 import com.iccas.zen.presentation.chatBot.components.TopBar

--- a/app/src/main/java/com/iccas/zen/presentation/chatBot/SelectEmotionScreen.kt
+++ b/app/src/main/java/com/iccas/zen/presentation/chatBot/SelectEmotionScreen.kt
@@ -17,14 +17,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.iccas.zen.R
+import com.iccas.zen.presentation.chatBot.ChatViewModel
 import com.iccas.zen.presentation.components.BasicBackgroundWithLogo
 import com.iccas.zen.presentation.chatBot.components.TopBar
 import com.iccas.zen.presentation.chatBot.components.EmotionHeader
 
 @Composable
-fun SelectEmotionScreen(navController: NavHostController) {
+fun SelectEmotionScreen(navController: NavHostController, characterImageRes: Int, characterDescription: String) {
     val whatHappenedState = remember { mutableStateOf("") }
     val howFeelingState = remember { mutableStateOf("") }
     val whyFeelingState = remember { mutableStateOf("") }
@@ -38,30 +40,30 @@ fun SelectEmotionScreen(navController: NavHostController) {
 
             // 감정 헤더 추가
             EmotionHeader(
-                imageResId = R.drawable.chat_bao,
-                imageDescription = "Bao",
+                imageResId = characterImageRes,
+                imageDescription = characterDescription,
                 imageSize = 60.dp,
-                title = "BAO",
+                title = characterDescription,
                 message = "What happened today?",
                 question = "Can you describe what happened?",
                 inputState = whatHappenedState
             )
 
             EmotionHeader(
-                imageResId = R.drawable.chat_bao,
-                imageDescription = "Bao",
+                imageResId = characterImageRes,
+                imageDescription = characterDescription,
                 imageSize = 60.dp,
-                title = "BAO",
+                title = characterDescription,
                 message = "How are you feeling today?",
                 question = "How are you feeling?",
                 inputState = howFeelingState
             )
 
             EmotionHeader(
-                imageResId = R.drawable.chat_bao,
-                imageDescription = "Bao",
+                imageResId = characterImageRes,
+                imageDescription = characterDescription,
                 imageSize = 60.dp,
-                title = "BAO",
+                title = characterDescription,
                 message = "Why do you feel that way?",
                 question = "Can you explain why you feel that way?",
                 inputState = whyFeelingState
@@ -80,28 +82,32 @@ fun SelectEmotionScreen(navController: NavHostController) {
                     R.drawable.chat_happy,
                     "Happy",
                     70.dp,
-                    "You feel happy because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}."
+                    "You feel happy because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}.",
+                    characterDescription
                 )
                 EmotionButton(
                     navController,
                     R.drawable.chat_soso,
                     "Soso",
                     70.dp,
-                    "You feel so-so because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}."
+                    "You feel so-so because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}.",
+                    characterDescription
                 )
                 EmotionButton(
                     navController,
                     R.drawable.chat_sad,
                     "Sad",
                     70.dp,
-                    "You feel sad because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}."
+                    "You feel sad because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}.",
+                    characterDescription
                 )
                 EmotionButton(
                     navController,
                     R.drawable.chat_angry,
                     "Angry",
                     70.dp,
-                    "You feel angry because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}."
+                    "You feel angry because ${whatHappenedState.value}, ${howFeelingState.value}, and ${whyFeelingState.value}.",
+                    characterDescription
                 )
             }
         }
@@ -109,13 +115,23 @@ fun SelectEmotionScreen(navController: NavHostController) {
 }
 
 @Composable
-fun EmotionButton(navController: NavHostController, imageResId: Int, label: String, size: Dp, promptPrefix: String) {
+fun EmotionButton(
+    navController: NavHostController,
+    imageResId: Int,
+    label: String,
+    size: Dp,
+    promptPrefix: String,
+    characterDescription: String
+) {
+    val viewModel: ChatViewModel = viewModel()
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .clickable {
                 Log.d("EmotionButton", "Prompt Prefix: $promptPrefix")
-                navController.navigate("chat_screen/$imageResId?prompt=${promptPrefix.encode()}")
+                viewModel.postEmotionDiary(promptPrefix, characterDescription, label)
+                navController.navigate("chat_screen/$imageResId?prompt=${promptPrefix.encode()}&characterDescription=$characterDescription")
             }
             .padding(8.dp)
     ) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #40 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- user 답변 저장 api 를 연동했습니다.
- DiaryCharSelectScreen 과 selectEmotionScreen을 연동했습니다.
- db에 선택한 감정 및 캐릭터가 저장되도록 했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 구현화면
<!-- postman 스크린샷 혹은 구현된 화면을 첨부해주세요 -->
<img width="1018" alt="스크린샷 2024-07-20 오전 2 36 43" src="https://github.com/user-attachments/assets/daf72569-190e-4a03-8f2b-aa0f1f9f7929">

https://github.com/user-attachments/assets/0532396b-6201-4a4e-99bb-1d985de35b92

